### PR TITLE
Fix binary extraction flow

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -78,7 +78,13 @@ dotnet publish -c Release -r linux-x64 --self-contained
 dotnet publish -c Release -r win-x64 --self-contained
 ```
 
-3. Archive and package binaries into `./dist/`:
+3. Build a binary for MacOS:
+
+```bash
+dotnet publish -c Release -r osx-x64 --self-contained
+```
+
+4Archive and package binaries into `./dist/`:
 
 
 ## Running Tests

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -84,7 +84,7 @@ dotnet publish -c Release -r win-x64 --self-contained
 dotnet publish -c Release -r osx-x64 --self-contained
 ```
 
-4Archive and package binaries into `./dist/`:
+4. Archive and package binaries into `./dist/`:
 
 
 ## Running Tests


### PR DESCRIPTION
### Refactor: 
- **Fix Binary Extraction in XmlPowerToolsEngine** - The binary extraction flow is broken and will not extract binaries unless fixed. This PR fixes this bug.


### Update: 
- Added MacOS Binary Build Instructions to Developer's Guide
