### PR TITLE
Document shallow-clone workaround for bloated repo history

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ a level of maturity similar to WmlComparer. At the moment it is NOT included.
 
 ## Getting started
 
+> **Cloning slowly?** Older commits in this repository include large build
+> artifacts (~1 GB total) that are no longer part of the project. If you only
+> need the current code, skip that history with a shallow or blobless clone:
+>
+> ```bash
+> # Fastest — latest commit only:
+> git clone --depth=1 https://github.com/JSv4/Python-Redlines.git
+>
+> # Full history, but download file contents lazily (skips the old archives):
+> git clone --filter=blob:none https://github.com/JSv4/Python-Redlines.git
+> ```
+
 ### Install .NET Core 8
 
 The Open-XML-PowerTools engine we're using in the initial releases requires .NET to run (don't worry, this is very 


### PR DESCRIPTION
## Summary

Cloning this repo currently pulls **~1 GB** even though the working tree is only ~224 KB. The bloat is entirely in **git history**: 23 platform binary archives (`win-x64`/`linux-x64`/`osx-x64`, `.zip` + `.tar.gz`, ~70 MB each, versions 0.0.1–0.0.4) that were committed early on and later removed in the "Drop binaries" commits. Nothing references them anymore — every clone just re-downloads them.

This PR adds a README note pointing new clones at `--depth=1` / `--filter=blob:none`, which skips that dead history (~1 GB → a few hundred KB) with **zero changes to the repo**.

## Permanently shrinking the repo (history rewrite)

The README note is a workaround. The only way to *actually* shrink the repo is to rewrite history. This is destructive and affects all collaborators, so it is left for a maintainer to run deliberately. **Verified locally: this drops `.git` from 1.1 GB to ~296 KB** (63 commits rewritten, all 23 archives removed).

### Runbook

**0. Merge or close all open PRs first** (including this one). Rewriting changes every commit SHA, so any open PR's commits will no longer exist on the rewritten branch.

**1. Back up the repo:**
```bash
git clone --mirror https://github.com/JSv4/Python-Redlines.git Python-Redlines-backup.git
```

**2. Fresh mirror clone to operate on:**
```bash
git clone --mirror https://github.com/JSv4/Python-Redlines.git
cd Python-Redlines.git
```

**3. Strip the large blobs** (`pip install git-filter-repo` first):
```bash
git filter-repo --strip-blobs-bigger-than 1M --force
```
Safe because the largest legitimate tracked file is a 14 KB test fixture — nothing real is over 1 MB. Precise alternative: `git filter-repo --path-glob '*.zip' --path-glob '*.tar.gz' --invert-paths --force`.

**4. Force-push.** filter-repo removes `origin` as a safety measure, so re-add it:
```bash
git remote add origin https://github.com/JSv4/Python-Redlines.git
git push --force --mirror origin
```
`--mirror` updates all branches and tags — review `git branch` / `git tag` in the mirror first so nothing is unexpectedly deleted.

**5. Ask GitHub Support to reclaim space.** A force-push does **not** shrink the repo on GitHub's side: the old commits stay reachable via internal `refs/pull/*` refs, so GitHub keeps serving the 1 GB pack until it garbage-collects. There is no self-serve button — open a ticket at https://support.github.com/, explain you have rewritten history to remove large files, and ask them to run `git gc`. Until then, fresh clones may still be large.

**6. All collaborators re-clone.** Every existing clone now has divergent history; re-cloning fresh is simplest. Local work on top of old SHAs must be rebased onto the new history.

### Caveats

- Version tags (`v0.0.1`–`v0.0.4`) point to new commit SHAs after the rewrite. `pip install ...@v0.0.1` keeps working.
- `pip install git+https://...` clones the repo too, so end users currently download the 1 GB as well — the rewrite fixes that for them.
- `.gitignore` already excludes `dist/` and `src/python_redlines/data/`, so the archives will not be reintroduced.

## Test plan

- [ ] Confirm the README note renders correctly on GitHub
- [ ] (Maintainer) Run the rewrite runbook above when ready to coordinate with collaborators

https://claude.ai/code/session_01XKJn4R6juXkHmjrezFsKMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKJn4R6juXkHmjrezFsKMV)_