### PR TITLE
Split into 3 packages + Docxodus engine + OIDC publishing (v0.2.0)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -64,19 +64,15 @@ jobs:
   publish:
     needs: [build-core, build-engine-wheels]
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/download-artifact@v4
       with:
         path: dist
         merge-multiple: true
-    - uses: actions/setup-python@v5
+    - uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        python-version: '3.11'
-    - run: pip install twine
-    - name: Check distributions
-      run: twine check dist/*
-    - name: Publish to PyPI
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: twine upload dist/*
+        packages-dir: dist

--- a/packages/core/src/python_redlines/__about__.py
+++ b/packages/core/src/python_redlines/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present U.N. Owen <void@some.where>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
## Summary
- Restructure the repo into three separately-published PyPI packages: `python-redlines` (pure-Python core), `python-redlines-ooxmlpowertools` (legacy engine binary), and `python-redlines-docxodus` (new default engine binary). Engines are now optional extras: `pip install python-redlines[docxodus]`, `[ooxmlpowertools]`, or `[all]`.
- Add `DocxodusEngine` — a .NET 8 fork of Open-XML-PowerTools (Docxodus) with move detection, format-change detection, and improved table handling. Made the default in the README.
- Switch the release workflow to PyPI Trusted Publishing (OIDC) via `pypa/gh-action-pypi-publish`; removes the long-lived `PYPI_API_TOKEN` and runs the publish job in the `pypi` environment matching three pending publishers configured on PyPI.
- Bump version to 0.2.0 (single source: `packages/core/src/python_redlines/__about__.py`, read by both binary packages).

## Test plan
- [x] Editable install of all three packages succeeds locally
- [x] README Quick Start runs end-to-end with `DocxodusEngine` → valid `.docx`, 9 revisions, `Reviewer` author
- [x] Legacy `XmlPowerToolsEngine` path still works; stdout matches `Revisions found: 9`
- [x] Comparison-settings kwargs (`detect_moves`, `simplify_move_markup`, `detail_threshold`, `case_insensitive`) accepted
- [x] `EngineNotInstalledError` raised with correct install hint when companion package missing
- [ ] CI passes on this PR
- [ ] After merge: tag `v0.2.0`, create GitHub Release, confirm publish workflow uploads all wheels to PyPI via OIDC